### PR TITLE
Add EMAIL environment variable

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -33,7 +33,7 @@ const getCurrentUser = () =>
  */
 const getCurrentUserMail = () =>
   vscode.workspace.getConfiguration()
-    .get('42header.email') || `${getCurrentUser()}@student.42.fr`
+    .get('42header.email') || process.env['EMAIL'] || `${getCurrentUser()}@student.42.fr`
 
 /**
  * Update HeaderInfo with last update author and date, and update filename


### PR DESCRIPTION
Add ability to change email address via environmental variable EMAIL.

This helps with docker development containers for visual studio, during build we can take an env. file and populate the users information and it will update the extension with the proper information. 
Currently only the username (USER) environmental variable is supported... This PR adds the ability to use the EMAIL variable as some students are not at student.42.fr.